### PR TITLE
fix: fatal: bad object

### DIFF
--- a/src/gitCommits.js
+++ b/src/gitCommits.js
@@ -9,7 +9,7 @@ const format = `%H${hashDelimiter}%B%n${commitDelimiter}`
 
 const buildGitArgs = (gitOpts) => {
   const { from, to, ...otherOpts } = gitOpts
-  const formatArg = `--format=${format}`
+  const formatArg = `--format="${format}"`
   const fromToArg = [from, to].filter(Boolean).join('..')
 
   const gitArgs = ['log', formatArg, fromToArg]


### PR DESCRIPTION
Error message:

```
Error: error running commitlint
Command failed with exit code 128: git log --format=%H--------->hash---------%B%n--------->commit--------- d9726f08e90f539e51a0accb3022c54cec103fb2 --first-parent --max-count=1
fatal: bad object d9726f08e90f539e51a0accb3022c54cec103fb2
Error: Command failed with exit code 128: git log --format=%H--------->hash---------%B%n--------->commit--------- d9726f08e90f539e51a0accb3022c54cec103fb2 --first-parent --max-count=1
fatal: bad object d9726f08e90f539e51a0accb3022c54cec103fb2
    at makeError (/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async gitCommits (/src/gitCommits.js:27:22)
    at async showLintResults (/src/action.js:123:19)
```